### PR TITLE
Add score image to /charities return

### DIFF
--- a/application/controllers/charities.py
+++ b/application/controllers/charities.py
@@ -7,7 +7,8 @@ charity_fields = {
     'id': fields.Integer,
     'url': fields.String,
     'name': fields.String,
-    'rating': fields.Integer
+    'rating': fields.Integer,
+    'rating_image': fields.String
 }
 
 charity_list_fields = {
@@ -36,6 +37,12 @@ item_post_parser.add_argument(
 )
 item_post_parser.add_argument(
     'rating',
+    type=str,
+    required=False,
+    location=['json']
+)
+item_post_parser.add_argument(
+    'rating_image',
     type=str,
     required=False,
     location=['json']

--- a/application/popos/charity.py
+++ b/application/popos/charity.py
@@ -1,6 +1,7 @@
 class Charity:
-    def __init__(self, id, name, url, rating):
+    def __init__(self, id, name, url, rating, rating_image):
         self.id = id
         self.url = url
         self.name = name
         self.rating = rating
+        self.rating_image = rating_image

--- a/application/services/charity_service.py
+++ b/application/services/charity_service.py
@@ -17,7 +17,8 @@ def charity_objects(response):
         name = charity["charityName"]
         url = charity["charityNavigatorURL"]
         rating = charity["currentRating"]["rating"]
-        charity_list.append(Charity(id, name, url, rating))
+        rating_image = charity["currentRating"]["ratingImage"]["large"]
+        charity_list.append(Charity(id, name, url, rating, rating_image))
 
     return charity_list
 


### PR DESCRIPTION
### Type of change made:
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling - no new features
### Why is this change required? What problem does it solve?
- FE team wants to display the image of the rating.
### Were there any challenges that arose while implementing this feature? If so, how were they addressed?
- Originally wanted to pull some additional data that Charity Navigator keeps behind a paywall. Took a minute to figure out why documentation wasn't displaying what I was seeing in Postman.
